### PR TITLE
Fix API key being set incorrectly on script header not on the component itself

### DIFF
--- a/ViewModel/ViewModel.php
+++ b/ViewModel/ViewModel.php
@@ -139,6 +139,7 @@ class ViewModel implements ArgumentInterface
     public function getConfig()
     {
         return [
+            'api_key' => $this->helper->getApiKey(),
             'clipping' => 'clip-to-' . $this->helper->getClipping(),
             'save_coordinates' => $this->helper->getCoordinates(),
             'save_nearest' => $this->helper->getNearest(),

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "magento2-module",
     "license": "proprietary",
     "keywords": ["magento", "magento2", "what3words", "what3words address"],
-    "version": "3.0.5",
+    "version": "3.0.6",
     "authors": [
         {
             "name": "Vlad Patru",

--- a/view/frontend/templates/address/edit.phtml
+++ b/view/frontend/templates/address/edit.phtml
@@ -173,6 +173,7 @@ $_fax = $block->getLayout()->createBlock(Fax::class) ?>
                 <div class="control <?= /** @noEscape  */ $tooltipClass;?>">
                     <div class="input-wrap-w3w">
                         <what3words-autosuggest
+                            api_key="<?= /** @noEscape  */ $viewModel->getApiKey(); ?>"
                             headers='{"X-W3W-Plugin": "what3words-Magento/<?=  /* @noEscape */ $viewModel->getConfig()['w3w_version'];?> ({Magento_version: <?= /* @noEscape */ $viewModel->getMagentoVersion();?> , Location: Account})"}'
                             id="autosuggest-w3w"  validation="true"
                             variant="inherit"

--- a/view/frontend/templates/headjs-include.phtml
+++ b/view/frontend/templates/headjs-include.phtml
@@ -7,7 +7,7 @@ $viewModel = $block->getViewModel();
 <?php if ($viewModel->getApiKey()) { ?>
     <script type="module" src="https://cdn.what3words.com/javascript-components@4-latest/dist/what3words/what3words.esm.js">
     </script>
-    <script nomodule src="https://cdn.what3words.com/javascript-components@4-latest/dist/what3words/what3words.js?key=<?= /** @noEscape  */ $viewModel->getApiKey(); ?>"></script>
+    <script nomodule src="https://cdn.what3words.com/javascript-components@4-latest/dist/what3words/what3words.js"></script>
     <script>
         window.w3wConfig = <?= /* @noEscape */ $viewModel->getSerializedConfig() ?>;
     </script>

--- a/view/frontend/web/js/component/w3wAutosuggest.js
+++ b/view/frontend/web/js/component/w3wAutosuggest.js
@@ -21,6 +21,7 @@ define([
                 headers = '{"X-W3W-Plugin": "what3words-Magento/'+ customData.w3w_version +' ({Magento_version:'+ customData.magento_version +' , Location: Checkout})"}';
 
             inputParent.setAttribute('headers', headers);
+            inputParent.setAttribute('api_key', customData.api_key);
 
             $(document).on('focus', '.what3words-autosuggest', function () {
                 var country = $('[name="country_id"] option:selected').val();

--- a/view/frontend/web/js/component/w3wAutosuggest.js
+++ b/view/frontend/web/js/component/w3wAutosuggest.js
@@ -21,7 +21,9 @@ define([
                 headers = '{"X-W3W-Plugin": "what3words-Magento/'+ customData.w3w_version +' ({Magento_version:'+ customData.magento_version +' , Location: Checkout})"}';
 
             inputParent.setAttribute('headers', headers);
-            inputParent.setAttribute('api_key', customData.api_key);
+            if (customData.api_key) {
+                inputParent.setAttribute('api_key', customData.api_key);
+            }
 
             $(document).on('focus', '.what3words-autosuggest', function () {
                 var country = $('[name="country_id"] option:selected').val();

--- a/view/frontend/web/js/w3wValidation.js
+++ b/view/frontend/web/js/w3wValidation.js
@@ -6,6 +6,7 @@ define(['jquery'], function ($) {
         $.validator.addMethod(
             'validate-w3w',
             function(value) {
+                // This can be updated to use the window.what3words.utils.validateAddress function instead so we don't another source of truth to update when we want to update RegEx.
                 return /^\/{0,}[^0-9`~!@#$%^&*()+\-_=[{\]}\\|'<,.>?/";:£§º©®\s]{1,}[・.。][^0-9`~!@#$%^&*()+\-_=[{\]}\\|'<,.>?/";:£§º©®\s]{1,}[・.。][^0-9`~!@#$%^&*()+\-_=[{\]}\\|'<,.>?/";:£§º©®\s]{1,}$/i.test(value);
             },
             $.mage.__("What3Words address is invalid.")


### PR DESCRIPTION
The API key is being set incorrectly and does not follow the documentation as specified to pass it to the component

This addresses that problem. I suspect that I have not found everywhere that needs updating as it not very clear from source code and lack of documentation where this change needs to be reflected as a whole and I've identified multiple places that would be capable of handling this.

## Changelog

* remove `?key=...` from `script` tag
* Add `api_key` to component attributes