### PR TITLE
 [TT-9573] Update autosuggest component version to v4.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "magento2-module",
     "license": "proprietary",
     "keywords": ["magento", "magento2", "what3words", "what3words address"],
-    "version": "3.0.10",
+    "version": "3.0.11",
     "authors": [
         {
             "name": "Vlad Patru",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="What3Words_What3Words" setup_version="2.0.3" module_version="3.0.10">
+    <module name="What3Words_What3Words" setup_version="2.0.3" module_version="3.0.11">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Customer"/>

--- a/view/frontend/templates/headjs-include.phtml
+++ b/view/frontend/templates/headjs-include.phtml
@@ -7,11 +7,11 @@ $viewModel = $block->getViewModel();
 <?php if ($viewModel->getApiKey()) { ?>
     <script
         type="module"
-        src="https://cdn.what3words.com/javascript-components@4.8.0/dist/what3words/what3words.esm.js">
+        src="https://cdn.what3words.com/javascript-components@4.9.0/dist/what3words/what3words.esm.js">
     </script>
     <script
         nomodule
-        src="https://cdn.what3words.com/javascript-components@4.8.0/dist/what3words/what3words.js">
+        src="https://cdn.what3words.com/javascript-components@4.9.0/dist/what3words/what3words.js">
     </script>
     <script>
         window.w3wConfig = <?= /* @noEscape */ $viewModel->getSerializedConfig() ?>;


### PR DESCRIPTION
Updated javascript-sdk version to v4.9.0 which adds a console log for any 402 errors thrown by the public API


https://github.com/user-attachments/assets/2991cccd-f8db-4e70-b195-b3ba17151e7c


<img width="1344" alt="image" src="https://github.com/user-attachments/assets/4261899c-8693-4e6b-bda3-aa7745f4312d">
