### PR TITLE
[TT-9573] Added note on save coordinate setting on admin page

### DIFF
--- a/Model/Config/Comment/SaveCoordinates.php
+++ b/Model/Config/Comment/SaveCoordinates.php
@@ -16,6 +16,6 @@ class SaveCoordinates implements CommentInterface
 {
     public function getCommentText($elementValue)
     {
-        return "NOTE: This feature won't work if you're on a free plan or have exceeded your quota. Check the console and network panel for errors. No coordinates will be saved. Please review our <a href=\"https://accounts.what3words.com/select-plan\">plans</a> for higher allowances.";
+        return "<strong>NOTE:</strong> This feature won't work if you're on a free plan or have exceeded your quota. Check the console and network panel for errors. No coordinates will be saved. Please review our <a href=\"https://accounts.what3words.com/select-plan\">plans</a> for higher allowances."
     }
 }

--- a/Model/Config/Comment/SaveCoordinates.php
+++ b/Model/Config/Comment/SaveCoordinates.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * What3Words_What3Words
+ *
+ * @category    Models
+ * @copyright   Copyright (c) 2024 What3Words
+ * @author      what3words Developer <developer@what3words.com>
+ * @link        http://www.what3words.com
+ */
+
+namespace What3Words\What3Words\Model\Config\Comment;
+
+use Magento\Config\Model\Config\CommentInterface;
+
+class SaveCoordinates implements CommentInterface
+{
+    public function getCommentText($elementValue)
+    {
+        return "NOTE: This feature won't work if you're on a free plan or have exceeded your quota. Check the console and network panel for errors. No coordinates will be saved. Please review our <a href=\"https://accounts.what3words.com/select-plan\">plans</a> for higher allowances.";
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "magento2-module",
     "license": "proprietary",
     "keywords": ["magento", "magento2", "what3words", "what3words address"],
-    "version": "3.0.11",
+    "version": "3.0.12",
     "authors": [
         {
             "name": "Vlad Patru",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -20,6 +20,7 @@
                 <field id="save_coordinates" translate="label" type="select" sortOrder="20" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Save coordinates</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>NOTE: This feature won't work if you're on a free plan or have exceeded your quota. Check the console and network panel for errors. No coordinates will be saved. Please review our <a href="https://accounts.what3words.com/select-plan">plans</a> for higher allowances.</comment>
                 </field>
                 <field id="save_nearest" translate="label" type="select" sortOrder="30" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Save nearest place</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -20,7 +20,9 @@
                 <field id="save_coordinates" translate="label" type="select" sortOrder="20" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Save coordinates</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment>NOTE: This feature won't work if you're on a free plan or have exceeded your quota. Check the console and network panel for errors. No coordinates will be saved. Please review our <a href="https://accounts.what3words.com/select-plan">plans</a> for higher allowances.</comment>
+                    <comment>
+                        <model>What3Words\What3Words\Model\Config\Comment\SaveCoordinates</model>
+                    </comment>
                 </field>
                 <field id="save_nearest" translate="label" type="select" sortOrder="30" showInDefault="1" showInStore="1" showInWebsite="1" canRestore="1">
                     <label>Save nearest place</label>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="What3Words_What3Words" setup_version="2.0.3" module_version="3.0.11">
+    <module name="What3Words_What3Words" setup_version="2.0.3" module_version="3.0.12">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Customer"/>


### PR DESCRIPTION
This change adds a comment under the `Save Coordinate` option on the plugin's settings page, to inform users that Convert to Coordinates won't work if capped or if user is on free plan.

![image](https://github.com/user-attachments/assets/53acbc55-1e0a-4500-8831-8a1de549b54c)
