### PR TITLE
TT-10027: Compatibility with Magento 2.4.8-p1

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -23,10 +23,22 @@ class Config extends AbstractHelper
 {
     const PREFIX = 'what3words/';
     const SCOPE_TYPE_STORE = 'store';
+
+    /**
+     * @var ProductMetadataInterface
+     */
+    private $productMetadata;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
     /**
      * Config constructor.
      * @param Context $context
      * @param ProductMetadataInterface $productMetadata
+     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         Context $context,
@@ -218,7 +230,7 @@ class Config extends AbstractHelper
     {
         $defaultMessage = 'what3words addresses help our delivery partners find you first time. Find yours at <a href="%1" target="_blank">what3words.com</a>';
         $partner = parse_url($this->storeManager->getStore()->getBaseUrl(), PHP_URL_HOST);
-        return $this->getShowTooltip() && $this->getConfig('frontend/tooltip_text') ? $this->getConfig('frontend/tooltip_text') : __($defaultMessage, 'https://delivery.w3w.co/?partner='. $partner);
+        return $this->getShowTooltip() && $this->getConfig('frontend/tooltip_text') ? $this->getConfig('frontend/tooltip_text') : __($defaultMessage, 'https://delivery.w3w.co/?partner=' . $partner);
     }
 
     /**

--- a/Model/Config/Comment/SaveCoordinates.php
+++ b/Model/Config/Comment/SaveCoordinates.php
@@ -16,6 +16,6 @@ class SaveCoordinates implements CommentInterface
 {
     public function getCommentText($elementValue)
     {
-        return "<strong>NOTE:</strong> This feature won't work if you're on a free plan or have exceeded your quota. Check the console and network panel for errors. No coordinates will be saved. Please review our <a href=\"https://accounts.what3words.com/select-plan\">plans</a> for higher allowances."
+        return "<strong>NOTE:</strong> This feature won't work if you're on a free plan or have exceeded your quota. Check the console and network panel for errors. No coordinates will be saved. Please review our <a href=\"https://accounts.what3words.com/select-plan\">plans</a> for higher allowances.";
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,27 +1,32 @@
 {
-    "name": "what3words/module-what3words",
-    "description": "Module adding custom shipping attribute for what3words address",
-    "type": "magento2-module",
-    "license": "proprietary",
-    "keywords": ["magento", "magento2", "what3words", "what3words address"],
-    "version": "3.0.12",
-    "authors": [
-        {
-            "name": "Vlad Patru",
-            "email": "vlad@wearewip.com",
-            "role": "developer"
-        }
-    ],
-    "require": {
-        "magento/framework": "^102.0.0 || ^103.0.0",
-        "php": "~7.3.0||~7.4.0|| ~8.0"
-    },
-    "autoload": {
-        "files": [
-            "registration.php"
-        ],
-        "psr-4": {
-            "What3Words\\What3Words\\": ""
-        }
+  "name": "what3words/module-what3words",
+  "description": "Module adding custom shipping attribute for what3words address",
+  "type": "magento2-module",
+  "license": "proprietary",
+  "keywords": [
+    "magento",
+    "magento2",
+    "what3words",
+    "what3words address"
+  ],
+  "version": "3.0.13",
+  "authors": [
+    {
+      "name": "Vlad Patru",
+      "email": "vlad@wearewip.com",
+      "role": "developer"
     }
+  ],
+  "require": {
+    "magento/framework": "^102.0.0 || ^103.0.0 || ^104.0.0",
+    "php": "~8.1.0||~8.2.0||~8.3.0"
+  },
+  "autoload": {
+    "files": [
+      "registration.php"
+    ],
+    "psr-4": {
+      "What3Words\\What3Words\\": ""
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,13 @@
     "what3words",
     "what3words address"
   ],
-  "version": "3.0.13",
+  "version": "4.0.0",
   "authors": [
+    {
+      "name": "what3words",
+      "email": "developer@what3words.com",
+      "role": "developer"
+    },
     {
       "name": "Vlad Patru",
       "email": "vlad@wearewip.com",
@@ -18,8 +23,8 @@
     }
   ],
   "require": {
-    "magento/framework": "^102.0.0 || ^103.0.0 || ^104.0.0",
-    "php": "~8.1.0||~8.2.0||~8.3.0"
+    "magento/framework": "^102.0.0 || ^103.0.0",
+    "php": "~8.1.0||~8.2.0||~8.3.0||~8.4.0"
   },
   "autoload": {
     "files": [

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
+        <csp>
+            <mode>
+                <storefront_checkout_index_index>
+                    <report_only>1</report_only>
+                </storefront_checkout_index_index>
+            </mode>
+            <policies>
+                <storefront_checkout_index_index>
+                    <scripts>
+                        <inline>1</inline>
+                    </scripts>
+                </storefront_checkout_index_index>
+            </policies>
+        </csp>
         <what3words>
             <general>
                 <circle_radius>1</circle_radius>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
     <policies>
         <policy id="script-src">
             <values>
@@ -14,6 +15,11 @@
         <policy id="style-src">
             <values>
                 <value id="w3w-google-fonts" type="host">fonts.googleapis.com</value>
+            </values>
+        </policy>
+        <policy id="font-src">
+            <values>
+                <value id="w3w_google_fonts" type="host">fonts.gstatic.com</value>
             </values>
         </policy>
     </policies>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="What3Words_What3Words" setup_version="2.0.3" module_version="3.0.13">
+    <module name="What3Words_What3Words" setup_version="2.0.3" module_version="4.0.0">
         <sequence>
             <module name="Magento_Sales" />
             <module name="Magento_Customer" />

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,10 +1,11 @@
-<?xml version="1.0" ?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="What3Words_What3Words" setup_version="2.0.3" module_version="3.0.12">
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="What3Words_What3Words" setup_version="2.0.3" module_version="3.0.13">
         <sequence>
-            <module name="Magento_Sales"/>
-            <module name="Magento_Customer"/>
-            <module name="Magento_Checkout"/>
+            <module name="Magento_Sales" />
+            <module name="Magento_Customer" />
+            <module name="Magento_Checkout" />
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
On June 10th, 2025, Adobe released Adobe Commerce version 2.4.8-p1. Any extension that is not compatible with 2.4.8-p1 by Aug 25th, 2025 will be removed from the [commercemarketplace.adobe.com](https://commercemarketplace.adobe.com/).